### PR TITLE
Added extra parameters for mirroring the image

### DIFF
--- a/cfg/UEyeCam.cfg
+++ b/cfg/UEyeCam.cfg
@@ -96,4 +96,10 @@ gen.add("frame_rate", double_t, RECONFIGURE_RUNNING,
 gen.add("pixel_clock", int_t, RECONFIGURE_RUNNING,
   "Pixel clock (MHz)", 25, 1, 100)
 
+
+gen.add("flip_upd", bool_t, RECONFIGURE_RUNNING,
+  "Mirror Upside Down", False)
+gen.add("flip_lr", bool_t, RECONFIGURE_RUNNING,
+  "Mirror Left Right", False)
+
 exit(gen.generate(PACKAGE, "ueye_cam", "UEyeCam"))

--- a/include/ueye_cam/ueye_cam_driver.hpp
+++ b/include/ueye_cam/ueye_cam_driver.hpp
@@ -320,6 +320,22 @@ public:
   INT setStandbyMode();
 
   /**
+   * Mirrors the camera image upside down
+   * \param flip_horizontal Wheter to flip the image upside down or not.
+   *
+   * \return IS_SUCCESS if successful, error flag otherwise (see err2str).
+   */
+  INT setMirrorUpsideDown(bool flip_horizontal);
+
+  /**
+   * Mirrors the camera image left to right
+   * \param flip_vertical Wheter to flip the image left to right or not.
+   *
+   * \return IS_SUCCESS if successful, error flag otherwise (see err2str).
+   */
+  INT setMirrorLeftRight(bool flip_vertical);
+
+  /**
    * Waits for next frame to be available, then returns pointer to frame if successful.
    * This function should only be called when the camera is in live capture mode.
    * Since this function will block until the next frame is available, it can be used

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -810,6 +810,29 @@ INT UEyeCamDriver::setExtTriggerMode() {
   return is_err;
 };
 
+INT UEyeCamDriver::setMirrorUpsideDown(bool flip_horizontal){
+  if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;
+
+  INT is_err = IS_SUCCESS;
+  if(flip_horizontal)
+     is_err = is_SetRopEffect(cam_handle_,IS_SET_ROP_MIRROR_UPDOWN,1,0);
+  else
+     is_err = is_SetRopEffect(cam_handle_,IS_SET_ROP_MIRROR_UPDOWN,0,0);
+
+  return is_err;
+}
+
+INT UEyeCamDriver::setMirrorLeftRight(bool flip_vertical){
+  if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;
+
+  INT is_err = IS_SUCCESS;
+  if(flip_vertical)
+     is_err = is_SetRopEffect(cam_handle_,IS_SET_ROP_MIRROR_LEFTRIGHT,1,0);
+  else
+     is_err = is_SetRopEffect(cam_handle_,IS_SET_ROP_MIRROR_LEFTRIGHT,0,0);
+
+  return is_err;
+}
 
 INT UEyeCamDriver::setStandbyMode() {
   if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;


### PR DESCRIPTION
Added ROS dynamic reconfigure parameters to set IS_SET_ROP_MIRROR_LEFTRIGHT and IS_SET_ROP_MIRROR_UPDOWN.

I also changed the call to "parse_ini" to  a call to "parse" since, whatever way the camera calibration file was generated, you can convert the calibration file format from  INI to YAML and viceversa (see http://wiki.ros.org/camera_calibration_parsers). Expecting that a file that ends in .yml has its content in the INI format breaks other code that works with YAML files (e.g. the current implementation of MCPTAM).
