### PR TITLE
use frame_id from cam info files, not camera name

### DIFF
--- a/include/ueye_cam/ueye_cam_nodelet.hpp
+++ b/include/ueye_cam/ueye_cam_nodelet.hpp
@@ -81,6 +81,7 @@ public:
   constexpr static int DEFAULT_PIXEL_CLOCK = 25;
   constexpr static int DEFAULT_FLASH_DURATION = 1000;
 
+  const static std::string DEFAULT_FRAME_NAME;
   const static std::string DEFAULT_CAMERA_NAME;
   const static std::string DEFAULT_CAMERA_TOPIC;
   const static std::string DEFAULT_COLOR_MODE;
@@ -165,6 +166,7 @@ protected:
 
   ros::ServiceServer set_cam_info_srv_;
 
+  std::string frame_name_;
   std::string cam_topic_;
   std::string cam_intr_filename_;
   std::string cam_params_filename_; // should be valid UEye INI file


### PR DESCRIPTION
current implementation uses camera name as frame_id but if we want to use stereo processing, both camera need to have same frame_id (for example, see 
http://answers.ros.org/question/10376/stereovslam-error-assertion-left_tfframe-right_tfframe/, or https://github.com/ros-perception/image_pipeline/blob/indigo/camera_calibration/nodes/cameracalibrator.py#L370 )
I'm not so strongly confident, but it seems using camera name in calibration file for frame_id is correct way.
