### PR TITLE
fix frame_id related problem

### DIFF
--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -1061,10 +1061,10 @@ void UEyeCamNodelet::loadIntrinsicsFile() {
     cam_intr_filename_ = string(getenv("HOME")) + "/.ros/camera_info/" + cam_name_ + ".yaml";
   }
 
-  if (camera_calibration_parsers::readCalibration(cam_intr_filename_, frame_name_, ros_cam_info_)) {
+  if (camera_calibration_parsers::readCalibration(cam_intr_filename_, cam_name_, ros_cam_info_)) {
     NODELET_DEBUG_STREAM("Loaded intrinsics parameters for UEye camera " << cam_name_);
   }
-  ros_cam_info_.header.frame_id = frame_name_;
+  ros_cam_info_.header.frame_id = "/" + frame_name_;
 };
 
 


### PR DESCRIPTION
After applying PR #8, `frame_id` related problem still happened. 

```
average rate: 29.855
    min: 0.013s max: 0.040s std dev: 0.00295s window: 110
stereo_image_proc: /tmp/buildd/ros-hydro-image-geometry-1.10.18-0precise-20140819-2049/src/stereo_camera_model.cpp:35: bool image_geometry::StereoCameraModel::fromCameraInfo(const CameraInfo&, const CameraInfo&): Assertion `left_.tfFrame() == right_.tfFrame()' failed.
[stereo_image_proc-9] process has died [pid 24876, exit code -6, cmd /opt/ros/hydro/lib/stereo_image_proc/stereo_image_proc _approximate_sync:=True __name:=stereo_image_proc __log:=/home/yutaka/.ros/log/fb9ff4ba-422d-11e4-b275-00031d0df531/stereo_image_proc-9.log].
log file: /home/yutaka/.ros/log/fb9ff4ba-422d-11e4-b275-00031d0df531/stereo_image_proc-9*.log
average rate: 29.745
    min: 0.018s max: 0.043s std dev: 0.00322s window: 140
```

So I fix it with this PR. Please check and merge it.
