### PR TITLE
trim '/' prefix of topic and service to change to relative name-space

### DIFF
--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -149,8 +149,8 @@ void UEyeCamNodelet::onInit() {
   f = bind(&UEyeCamNodelet::configCallback, this, _1, _2);
 
   // Setup publishers, subscribers, and services
-  ros_cam_pub_ = it.advertiseCamera("/" + cam_name_ + "/" + cam_topic_, 1);
-  set_cam_info_srv_ = nh.advertiseService("/" + cam_name_ + "/set_camera_info",
+  ros_cam_pub_ = it.advertiseCamera(cam_name_ + "/" + cam_topic_, 1);
+  set_cam_info_srv_ = nh.advertiseService(cam_name_ + "/set_camera_info",
       &UEyeCamNodelet::setCamInfo, this);
 
   // Initiate camera and start capture


### PR DESCRIPTION
Before this PR is not patched, we cannot change namespace of camera topic and service. For example, 

``` sh
% ROS_NAMESPACE=stereo roslaunch ueye_cam rgb8.launch
```

``` sh
% rostopic list
/camera/camera_info
/camera/image_raw
/camera/image_raw/compressed
/camera/image_raw/compressed/parameter_descriptions
/camera/image_raw/compressed/parameter_updates
/camera/image_raw/compressedDepth
/camera/image_raw/compressedDepth/parameter_descriptions
/camera/image_raw/compressedDepth/parameter_updates
/camera/image_raw/theora
/camera/image_raw/theora/parameter_descriptions
/camera/image_raw/theora/parameter_updates
/rosout
/rosout_agg
/stereo/nodelet_manager/bond
/stereo/ueye_cam_nodelet/parameter_descriptions
/stereo/ueye_cam_nodelet/parameter_updates
```

After patched, we can do it.

``` sh
% rostopic list
/rosout
/rosout_agg
/stereo/camera/camera_info
/stereo/camera/image_raw
/stereo/camera/image_raw/compressed
/stereo/camera/image_raw/compressed/parameter_descriptions
/stereo/camera/image_raw/compressed/parameter_updates
/stereo/camera/image_raw/compressedDepth
/stereo/camera/image_raw/compressedDepth/parameter_descriptions
/stereo/camera/image_raw/compressedDepth/parameter_updates
/stereo/camera/image_raw/theora
/stereo/camera/image_raw/theora/parameter_descriptions
/stereo/camera/image_raw/theora/parameter_updates
/stereo/nodelet_manager/bond
/stereo/ueye_cam_nodelet/parameter_descriptions
/stereo/ueye_cam_nodelet/parameter_updates
```
