### PR TITLE
Fix for reported ARM arch on Fedora

### DIFF
--- a/cmake_modules/DownloadUEyeDriversUnofficial.cmake
+++ b/cmake_modules/DownloadUEyeDriversUnofficial.cmake
@@ -22,6 +22,8 @@ function(download_ueye_drivers UEYE_LIBRARY_VAR UEYE_INCLUDE_DIR_VAR UEYE_DRIVER
     target_architecture(UEYE_ARCH)
     if (UEYE_ARCH STREQUAL "x86_64")
       set (UEYE_ARCH "amd64")
+    elseif (UEYE_ARCH STREQUAL "armv7")
+      set (UEYE_ARCH "arm")
     endif ()
     
     # Set download path (credits due to ueye ROS package developers)


### PR DESCRIPTION
Looks like Fedora reports `armv7` for the target_architecture on `armv7hl`.

Example Indigo break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-ueye-cam_binaryrpm_heisenbug_armhfp/15/consoleFull

Example Jade break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-jade-ueye-cam_binaryrpm_21_armhfp/1/consoleFull

Thanks,

--scott