### PR TITLE
Modified nodelet to use camera timestamp instead of wall clock time

### DIFF
--- a/include/ueye_cam/ueye_cam_driver.hpp
+++ b/include/ueye_cam/ueye_cam_driver.hpp
@@ -380,6 +380,11 @@ public:
    */
   const static char* colormode2str(INT mode);
 
+  /**
+   * Sets a timestamp indicating the moment of the image capture
+   */
+  bool getTimestamp(UEYETIME *timestamp);
+
 
 protected:
   /**

--- a/include/ueye_cam/ueye_cam_nodelet.hpp
+++ b/include/ueye_cam/ueye_cam_nodelet.hpp
@@ -158,6 +158,11 @@ protected:
   void startFrameGrabber();
   void stopFrameGrabber();
 
+  /**
+   * Returns image's timestamp or current wall time if driver call fails.
+   */
+  ros::Time getImageTimestamp();
+
   std::thread frame_grab_thread_;
   bool frame_grab_alive_;
 

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -1284,5 +1284,13 @@ const char* UEyeCamDriver::colormode2str(INT mode) {
 #undef CASE
 }
 
+bool UEyeCamDriver::getTimestamp(UEYETIME *timestamp) {
+  UEYEIMAGEINFO ImageInfo;
+  if(is_GetImageInfo (cam_handle_, cam_buffer_id_, &ImageInfo, sizeof (ImageInfo)) == IS_SUCCESS) {
+    *timestamp = ImageInfo.TimestampSystem;
+    return true;
+  }
+  return false;
+}
 
 } // namespace ueye_cam

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -949,6 +949,7 @@ void UEyeCamNodelet::frameGrabLoop() {
       INT eventTimeout = (cam_params_.auto_frame_rate || cam_params_.ext_trigger_mode) ?
           (INT) 2000 : (INT) (1000.0 / cam_params_.frame_rate * 2);
       if (processNextFrame(eventTimeout) != NULL) {
+        ros_image_.header.stamp = ros_cam_info_.header.stamp = getImageTimestamp();
         // Process new frame
 #ifdef DEBUG_PRINTOUT_FRAME_GRAB_RATES
         grabbedFrameCount++;
@@ -999,7 +1000,6 @@ void UEyeCamNodelet::frameGrabLoop() {
           }
           ros_image_.step = expected_row_stride; // fix the row stepsize/stride value
         }
-        ros_image_.header.stamp = ros_cam_info_.header.stamp = ros::Time::now();
         ros_image_.header.seq = ros_cam_info_.header.seq = ros_frame_count_++;
         ros_image_.header.frame_id = ros_cam_info_.header.frame_id;
 
@@ -1053,6 +1053,21 @@ bool UEyeCamNodelet::saveIntrinsicsFile() {
     return true;
   }
   return false;
+}
+
+ros::Time UEyeCamNodelet::getImageTimestamp() {
+  UEYETIME utime;
+  if(getTimestamp(&utime)) {
+    struct tm tm;
+    tm.tm_year = utime.wYear - 1900;
+    tm.tm_mon = utime.wMonth - 1;
+    tm.tm_mday = utime.wDay;
+    tm.tm_hour = utime.wHour;
+    tm.tm_min = utime.wMinute;
+    tm.tm_sec = utime.wSecond;
+    return ros::Time(mktime(&tm),utime.wMilliseconds*1e6);
+  }
+  return ros::Time::now();
 }
 // TODO: 0 bug where nodelet locks and requires SIGTERM when there are still subscribers (need to find where does code hang)
 


### PR DESCRIPTION
The idea of this is to hopefully get a more accurate image timestamp to improve synchronization