### PR TITLE
add check_ueye_api and run within rgb8.launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ add_library(${UEYECAM_NODELET_NAME} ${UEYECAM_NODELET_SOURCES} ${UEYECAM_NODELET
 target_link_libraries(${UEYECAM_NODELET_NAME} ${catkin_LIBRARIES} ${UEYECAM_LIB_NAME})
 add_dependencies(${UEYECAM_NODELET_NAME} ${PROJECT_NAME}_gencfg)
 
+add_executable(check_ueye_api src/check_ueye_api.cpp)
+target_link_libraries(check_ueye_api ${catkin_LIBRARIES} ${UEYECAM_LIB_NAME})
+
 # Do not package the barebones IDS drivers, since they will mask over the official drivers (when present)
 #if(USE_UNOFFICIAL_UEYE_DRIVERS)
 #  get_filename_component(UNOFFICIAL_UEYE_DRIVERS_LIB_REALPATH ${UEYE_LIBRARY} REALPATH)

--- a/launch/rgb8.launch
+++ b/launch/rgb8.launch
@@ -1,4 +1,5 @@
 <launch>
+  <param name="check_ueye_api" command="rosrun ueye_cam check_ueye_api" />
   <arg name="nodelet_manager_name" value="nodelet_manager" />
   <arg name="camera_name" value="camera" />
 

--- a/src/check_ueye_api.cpp
+++ b/src/check_ueye_api.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* SOFTWARE LICENSE AGREEMENT (BSD LICENSE):
+*
+* Copyright (c) 2016, Kei Okada
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+*  * Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above
+*    copyright notice, this list of conditions and the following
+*    disclaimer in the documentation and/or other materials provided
+*    with the distribution.
+*  * Neither the name of the School of Computer Science, McGill University,
+*    nor the names of its contributors may be used to endorse or promote
+*    products derived from this software without specific prior written
+*    permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <dlfcn.h>
+#include <ros/ros.h>
+
+int main() {
+  void *handle;
+  handle = dlopen("libueye_api.so", RTLD_LAZY);
+  if ( ! handle ) {
+    ROS_ERROR("The official IDS uEye driver (libueye_api.so) were not detected on your machine.");
+    ROS_ERROR("You (or a system administrator) MUST still download and install the official IDS uEye drivers (http://en.ids-imaging.com/download-ueye.html).");
+    ROS_ERROR("Also make sure that the IDS daemon (/etc/init.d/ueyeusbdrc) is running.");
+    exit(1);
+  }
+  exit(0);
+}


### PR DESCRIPTION
this may help people who confused without install driver (#21)

this will outputs like

```
k-okada@kokada-t440s:/tmp/hoge/src/ueye_cam$ roslaunch launch/rgb8.launch ... logging to /home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/roslaunch-kokada-t440s-10735.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/home/k-okada/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.

[ERROR] [1452399057.321138428]: The official IDS uEye driver (libueye_api.so) were not detected on your machine.
[ERROR] [1452399057.321196612]: You (or a system administrator) MUST still download and install the official IDS uEye drivers (http://en.ids-imaging.com/download-ueye.html).
[ERROR] [1452399057.321216126]: Also make sure that the IDS daemon (/etc/init.d/ueyeusbdrc) is running.
Invalid <param> tag: Cannot load command parameter [check_ueye_api]: command [rosrun ueye_cam check_ueye_api] returned with code [1]. 

Param xml is <param command="rosrun ueye_cam check_ueye_api" name="check_ueye_api"/>
The traceback for the exception was written to the log file

```