### PR TITLE
Separate publish and poll rates

### DIFF
--- a/cfg/UEyeCam.cfg
+++ b/cfg/UEyeCam.cfg
@@ -94,6 +94,8 @@ gen.add("auto_frame_rate", bool_t, RECONFIGURE_RUNNING,
   "Auto frame rate (requires auto exposure, supercedes auto gain) [not applicable in external trigger mode]", False) 
 gen.add("frame_rate", double_t, RECONFIGURE_RUNNING,
   "Frame rate (Hz) [not applicable in external trigger mode]", 10.0, 0.01, 200.0)
+gen.add("output_rate", double_t, RECONFIGURE_RUNNING,
+  "Output rate (Hz) [not applicable in external trigger mode]", 10.0, 0.01, 200.0)
 gen.add("pixel_clock", int_t, RECONFIGURE_RUNNING,
   "Pixel clock (MHz)", 25, 1, 500)
 

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -444,7 +444,9 @@ INT UEyeCamNodelet::parseROSParams(ros::NodeHandle& local_nh) {
           cam_params_.output_rate <<
           "; using current frame rate: " << prevCamParams.output_rate);
         cam_params_.output_rate = prevCamParams.output_rate;
-      } else {
+      } 
+      else {
+      	cam_params_.output_rate = std::min( cam_params_.frame_rate, cam_params_.output_rate );
         hasNewParams = true;
       }
     }
@@ -1001,6 +1003,7 @@ void UEyeCamNodelet::frameGrabLoop() {
 
         if (!frame_grab_alive_ || !ros::ok()) break;
         
+        // Only process and publish the frame if we're slower than the requested rate
 		double rate_hz = 1.0 / ( ros_image_.header.stamp - last_image_stamp ).toSec();
 		if ( rate_hz > cam_params_.output_rate ) continue;
 

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -446,7 +446,7 @@ INT UEyeCamNodelet::parseROSParams(ros::NodeHandle& local_nh) {
         cam_params_.output_rate = prevCamParams.output_rate;
       } 
       else {
-      	cam_params_.output_rate = std::min( cam_params_.frame_rate, cam_params_.output_rate );
+        cam_params_.output_rate = std::min( cam_params_.frame_rate, cam_params_.output_rate );
         hasNewParams = true;
       }
     }
@@ -1004,8 +1004,8 @@ void UEyeCamNodelet::frameGrabLoop() {
         if (!frame_grab_alive_ || !ros::ok()) break;
         
         // Only process and publish the frame if we're slower than the requested rate
-		double rate_hz = 1.0 / ( ros_image_.header.stamp - last_image_stamp ).toSec();
-		if ( rate_hz > cam_params_.output_rate ) continue;
+        double rate_hz = 1.0 / ( ros_image_.header.stamp - last_image_stamp ).toSec();
+        if ( rate_hz > cam_params_.output_rate ) continue;
 
         ros_cam_info_.width = cam_params_.image_width / cam_sensor_scaling_rate_ / cam_binning_rate_;
         ros_cam_info_.height = cam_params_.image_height / cam_sensor_scaling_rate_ / cam_binning_rate_;
@@ -1040,7 +1040,7 @@ void UEyeCamNodelet::frameGrabLoop() {
         if (!frame_grab_alive_ || !ros::ok()) break;
 
         ros_cam_pub_.publish(ros_image_, ros_cam_info_); 
-		last_image_stamp = ros_image_.header.stamp;
+        last_image_stamp = ros_image_.header.stamp;
       }
     }
 


### PR DESCRIPTION
Added `output_rate` parameter to control the output rate (ie. images processed and published) vs the camera poll rate (`frame_rate`). On most cameras the poll rate indirectly controls device properties such as exposure and affects the imagery. This change allows users to downsample the publication rate without affecting the quality of the imagery.

by default `output_rate=frame_rate`
