### PR TITLE
Added change of GPIO mode to be used as trigger.

### DIFF
--- a/cfg/UEyeCam.cfg
+++ b/cfg/UEyeCam.cfg
@@ -98,6 +98,14 @@ gen.add("flash_duration", int_t, RECONFIGURE_RUNNING,
 
 gen.add("ext_trigger_mode", bool_t, RECONFIGURE_STOP,
   "Toggle between external trigger mode and free-run mode", False)
+gpio_enum = gen.enum([
+  gen.const("INPUT", int_t, 0, "Input"),
+  gen.const("TRIGGER", int_t, 1, "Trigger")],
+  "Mode of a GPIO pin")
+gen.add("gpio1", int_t, RECONFIGURE_STOP,
+  "Mode for GPIO1 (pin 5)", 0, edit_method=gpio_enum)
+gen.add("gpio2", int_t, RECONFIGURE_STOP,
+  "Mode for GPIO2 (pin 6)", 0, edit_method=gpio_enum)
 
 gen.add("auto_frame_rate", bool_t, RECONFIGURE_RUNNING,
   "Auto frame rate (requires auto exposure, supercedes auto gain) [not applicable in external trigger mode]", False) 

--- a/include/ueye_cam/ueye_cam_driver.hpp
+++ b/include/ueye_cam/ueye_cam_driver.hpp
@@ -298,6 +298,17 @@ public:
   INT setFreeRunMode();
 
   /**
+   * Sets the mode for the GPIO pin.
+   * \param GPIO pin to be set {GPIO1: 1, GPIO2: 2}.
+   * \param mode for GPIO pin {0: input, 1: trigger}.
+   *
+   * \return IS_SUCCESS if successful, error flag otherwise (see err2str).
+   *
+   * @todo include also other modes.
+   */
+  INT setGpioMode(const int& gpio, int& mode);
+
+  /**
    * Sets current camera to external trigger mode, where a HI to LO falling-edge
    * signal on the digital input pin of the camera will trigger the camera to
    * capture a frame. This function also resets the digital output pin to

--- a/launch/master_slaves_rgb8.launch
+++ b/launch/master_slaves_rgb8.launch
@@ -62,6 +62,7 @@
     <param name="camera_parameters_file" type="string" value="" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
 
     <param name="ext_trigger_mode" type="bool" value="True" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
+    <param name="gpio1" type="int" value="1" /> <!-- Set mode for GPIO1: 0 = Input; 1 = Trigger -->
 
     <!-- the following are optional camera configuration parameters:
          they will be loaded on the camera after the .ini configuration
@@ -114,6 +115,7 @@
     <param name="camera_parameters_file" type="string" value="" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
 
     <param name="ext_trigger_mode" type="bool" value="True" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
+    <param name="gpio1" type="int" value="1" /> <!-- Set mode for GPIO1: 0 = Input; 1 = Trigger -->
 
     <!-- the following are optional camera configuration parameters:
          they will be loaded on the camera after the .ini configuration

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -825,6 +825,36 @@ INT UEyeCamDriver::setFreeRunMode() {
   return is_err;
 }
 
+INT UEyeCamDriver::setGpioMode(const int& gpio, int& mode) {
+  /* Set GPIO to a specific mode. */
+  INT is_err = IS_SUCCESS;
+
+  IO_GPIO_CONFIGURATION gpioConfiguration;
+   
+  if (gpio == 1)
+    // GPIO1 (pin 5).
+    gpioConfiguration.u32Gpio = IO_GPIO_1;
+  else if (gpio == 2)
+    // GPIO2 (pin 6).
+    gpioConfiguration.u32Gpio = IO_GPIO_2;
+
+  if (mode == 0)
+    gpioConfiguration.u32Configuration = IS_GPIO_INPUT;
+  else if (mode == 1)
+    gpioConfiguration.u32Configuration = IS_GPIO_TRIGGER;
+  gpioConfiguration.u32State = 0;
+
+  is_err = is_IO(cam_handle_, IS_IO_CMD_GPIOS_SET_CONFIGURATION, (void*)&gpioConfiguration, 
+              sizeof(gpioConfiguration));
+  if (is_err == IS_SUCCESS)
+    DEBUG_STREAM("GPIO " << gpio << " set as " << mode << " for [" << cam_name_ << "]");
+  else
+    ERROR_STREAM("Could not set pin " << gpio << " of [" << cam_name_ <<
+        "] to " << mode);
+    
+  return is_err;
+
+}
 
 INT UEyeCamDriver::setExtTriggerMode() {
   if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;


### PR DESCRIPTION
The included mode for the GPIO pins are Input and Trigger. It is easy to extend it to include other modes but wanted to avoid accidental change of GPIO pins (e.g., as output). 
Tested on two USB3 IDS 3251LE cameras with a TinyLily as a trigger.