### PR TITLE
Adapted roslaunch for passing camera name as argument

### DIFF
--- a/launch/bayer_rggb_image_proc.launch
+++ b/launch/bayer_rggb_image_proc.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="nodelet_manager_name" value="nodelet_manager" />
+  <arg name="nodelet_manager_name" default="nodelet_manager" />
   <arg name="camera_name" default="camera" />
 
   <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager_name)" args="manager" output="screen" />
@@ -10,8 +10,8 @@
     <param name="camera_name" type="str" value="$(arg camera_name)" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
-    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" />
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />  <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
+    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_conf/$(arg camera_name).ini" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
 
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 

--- a/launch/bayer_rggb_image_proc.launch
+++ b/launch/bayer_rggb_image_proc.launch
@@ -1,16 +1,17 @@
+<?xml version="1.0"?>
 <launch>
   <arg name="nodelet_manager_name" value="nodelet_manager" />
-  <arg name="camera_name" value="camera" />
+  <arg name="camera_name" default="camera" />
 
   <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager_name)" args="manager" output="screen" />
-  
+
   <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet"
         args="load ueye_cam/ueye_cam_nodelet $(arg nodelet_manager_name)">
     <param name="camera_name" type="str" value="$(arg camera_name)" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="" /> <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
-    <param name="camera_parameters_file" type="string" value="" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
+    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" />
 
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 

--- a/launch/bayer_rggb_image_proc.launch
+++ b/launch/bayer_rggb_image_proc.launch
@@ -48,10 +48,10 @@
     <param name="auto_white_balance" type="bool" value="True" />
     <param name="white_balance_red_offset" type="int" value="0" />
     <param name="white_balance_blue_offset" type="int" value="0" />
-    
+
     <param name="flash_delay" type="int" value="0" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-    
+
     <param name="auto_frame_rate" type="bool" value="False" />
     <param name="frame_rate" type="double" value="30.0" />
     <param name="output_rate" type="double" value="0.0" /> <!-- >0: throttle rate for publishing frames -->
@@ -60,7 +60,7 @@
     <param name="flip_upd" type="bool" value="False" />
     <param name="flip_lr"  type="bool" value="False" />
   </node>
-  
+
   <node pkg="nodelet" type="nodelet" name="debayer"
       args="load image_proc/debayer $(arg nodelet_manager_name)">
     <remap from="image_raw" to="/$(arg camera_name)/image_raw" />

--- a/launch/debug.launch
+++ b/launch/debug.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" output="screen" launch-prefix="gdb -ex run --args" />
-  
+
   <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet"
         args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
     <param name="camera_name" type="str" value="camera" /> <!-- == namespace for topics and services -->
@@ -11,7 +11,7 @@
     <param name="camera_parameters_file" type="string" value="" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
 
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
-    
+
     <!-- the following are optional camera configuration parameters:
          they will be loaded on the camera after the .ini configuration
          file, and before dynamic_reconfigure. That means that any
@@ -45,10 +45,10 @@
     <param name="auto_white_balance" type="bool" value="True" />
     <param name="white_balance_red_offset" type="int" value="0" />
     <param name="white_balance_blue_offset" type="int" value="0" />
-    
+
     <param name="flash_delay" type="int" value="0" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-    
+
     <param name="auto_frame_rate" type="bool" value="False" />
     <param name="frame_rate" type="double" value="30.0" />
     <param name="output_rate" type="double" value="0.0" /> <!-- >0: throttle rate for publishing frames -->

--- a/launch/debug.launch
+++ b/launch/debug.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
   <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" output="screen" launch-prefix="gdb -ex run --args" />
   

--- a/launch/master_slaves_rgb8.launch
+++ b/launch/master_slaves_rgb8.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
   <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" output="screen" />
 
@@ -6,8 +7,8 @@
     <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="4" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
-    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" />
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" /> <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
+    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
 
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 

--- a/launch/master_slaves_rgb8.launch
+++ b/launch/master_slaves_rgb8.launch
@@ -45,10 +45,10 @@
     <param name="auto_white_balance" type="bool" value="True" />
     <param name="white_balance_red_offset" type="int" value="0" />
     <param name="white_balance_blue_offset" type="int" value="0" />
-    
+
     <param name="flash_delay" type="int" value="30000" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-    
+
     <param name="auto_frame_rate" type="bool" value="False" />
     <param name="frame_rate" type="double" value="15.0" />
     <param name="pixel_clock" type="int" value="30" />
@@ -96,10 +96,10 @@
     <param name="auto_white_balance" type="bool" value="True" />
     <param name="white_balance_red_offset" type="int" value="0" />
     <param name="white_balance_blue_offset" type="int" value="0" />
-    
+
     <param name="flash_delay" type="int" value="0" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-    
+
     <param name="auto_frame_rate" type="bool" value="False" />
     <param name="frame_rate" type="double" value="15.0" />
     <param name="output_rate" type="double" value="0.0" /> <!-- >0: throttle rate for publishing frames -->
@@ -149,10 +149,10 @@
     <param name="auto_white_balance" type="bool" value="True" />
     <param name="white_balance_red_offset" type="int" value="0" />
     <param name="white_balance_blue_offset" type="int" value="0" />
-    
+
     <param name="flash_delay" type="int" value="0" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-    
+
     <param name="auto_frame_rate" type="bool" value="False" /> <!-- frame rate settings are ignored in camera_ext_trigger_mode -->
     <param name="frame_rate" type="double" value="15.0" /> <!-- frame rate settings are ignored in camera_ext_trigger_mode -->
     <param name="output_rate" type="double" value="0.0" /> <!-- frame publish throttling settings are ignored in camera_ext_trigger_mode -->

--- a/launch/master_slaves_rgb8.launch
+++ b/launch/master_slaves_rgb8.launch
@@ -1,13 +1,13 @@
 <launch>
   <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" output="screen" />
-  
+
   <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet_master"
         args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
     <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="4" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="" /> <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
-    <param name="camera_parameters_file" type="string" value="" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
+    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" />
 
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 

--- a/launch/rgb8.launch
+++ b/launch/rgb8.launch
@@ -1,18 +1,18 @@
+<?xml version="1.0"?>
 <launch>
   <node name="check_ueye_api" pkg="ueye_cam" type="check_ueye_api" required="true" />
-  <arg name="nodelet_manager_name" value="nodelet_manager" />
-  <arg name="camera_name" value="camera" />
+  <arg name="nodelet_manager_name" default="nodelet_manager" />
+  <arg name="camera_name" default="camera" />
 
   <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager_name)" args="manager" output="screen" />
-  
+
   <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet"
         args="load ueye_cam/ueye_cam_nodelet $(arg nodelet_manager_name)">
     <param name="camera_name" type="str" value="$(arg camera_name)" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="" /> <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
-    <param name="camera_parameters_file" type="string" value="" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
-
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
+    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" />
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 
     <!-- the following are optional camera configuration parameters:

--- a/launch/rgb8.launch
+++ b/launch/rgb8.launch
@@ -11,8 +11,8 @@
     <param name="camera_name" type="str" value="$(arg camera_name)" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
-    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" />
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" /> <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
+    <param name="camera_parameters_file" type="string" value="$(env HOME)/.ros/camera_parameters_file/$(arg camera_name).ini" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 
     <!-- the following are optional camera configuration parameters:

--- a/launch/rgb8.launch
+++ b/launch/rgb8.launch
@@ -48,10 +48,10 @@
     <param name="auto_white_balance" type="bool" value="True" />
     <param name="white_balance_red_offset" type="int" value="0" />
     <param name="white_balance_blue_offset" type="int" value="0" />
-    
+
     <param name="flash_delay" type="int" value="0" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-    
+
     <param name="auto_frame_rate" type="bool" value="False" />
     <param name="frame_rate" type="double" value="30.0" />
     <param name="output_rate" type="double" value="0.0" /> <!-- >0: throttle rate for publishing frames -->

--- a/launch/xs_bayer_rggb.launch
+++ b/launch/xs_bayer_rggb.launch
@@ -51,12 +51,12 @@
 
     <param name="flash_delay" type="int" value="0" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-    
+
     <param name="auto_frame_rate" type="bool" value="True" />
     <param name="frame_rate" type="double" value="30.0" />
     <param name="output_rate" type="double" value="0.0" /> <!-- >0: throttle rate for publishing frames -->
     <param name="pixel_clock" type="int" value="30" />
-    
+
     <param name="flip_upd" type="bool" value="False" />
     <param name="flip_lr"  type="bool" value="False" />
   </node>

--- a/launch/xs_bayer_rggb.launch
+++ b/launch/xs_bayer_rggb.launch
@@ -1,15 +1,16 @@
+<?xml version="1.0"?>
 <launch>
   <arg name="nodelet_manager_name" value="nodelet_manager" />
-  <arg name="camera_name" value="camera" />
+  <arg name="camera_name" default="camera" />
 
   <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager_name)" args="manager" output="screen" />
-  
+
   <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet"
         args="load ueye_cam/ueye_cam_nodelet $(arg nodelet_manager_name)">
     <param name="camera_name" type="str" value="$(arg camera_name)" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="" /> <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
     <param name="camera_parameters_file" type="string" value="$(find ueye_cam)/resources/xs.ini" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
 
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->

--- a/launch/xs_bayer_rggb.launch
+++ b/launch/xs_bayer_rggb.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="nodelet_manager_name" value="nodelet_manager" />
+  <arg name="nodelet_manager_name" default="nodelet_manager" />
   <arg name="camera_name" default="camera" />
 
   <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager_name)" args="manager" output="screen" />
@@ -10,7 +10,7 @@
     <param name="camera_name" type="str" value="$(arg camera_name)" /> <!-- == namespace for topics and services -->
     <param name="camera_topic" type="str" value="image_raw" />
     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
-    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" />
+    <param name="camera_intrinsics_file" type="string" value="$(env HOME)/.ros/camera_info/$(arg camera_name).yaml" /> <!-- default: ~/.ros/camera_info/<camera_name>.yaml -->
     <param name="camera_parameters_file" type="string" value="$(find ueye_cam)/resources/xs.ini" /> <!-- default: ~/.ros/camera_conf/<camera_name>.ini -->
 
     <param name="ext_trigger_mode" type="bool" value="False" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->


### PR DESCRIPTION
With this commit, one can pass camera_name as argument to the launch file

```
roslaunch ueye_cam rgb8.launch camera_name:=my_camera
```
