### PR TITLE
Check if camera supports sensor scaling before trying to set it

### DIFF
--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -539,8 +539,10 @@ INT UEyeCamNodelet::parseROSParams(ros::NodeHandle& local_nh) {
     if ((is_err = setBinning(cam_params_.binning, false)) != IS_SUCCESS) return is_err;
     if ((is_err = setResolution(cam_params_.image_width, cam_params_.image_height,
         cam_params_.image_left, cam_params_.image_top, false)) != IS_SUCCESS) return is_err;
-    if ((is_err = setSensorScaling(cam_params_.sensor_scaling, false)) != IS_SUCCESS) return is_err;
-
+    SENSORSCALERINFO sensorScalerInfo;  // Not all cameras support sensor scaling. Check if supported and only try to set it if supported
+    if (is_GetSensorScalerInfo(cam_handle_,&sensorScalerInfo, sizeof(sensorScalerInfo)) == IS_SUCCESS ) {
+      if ((is_err = setSensorScaling(cam_params_.sensor_scaling, false)) != IS_SUCCESS) return is_err;
+    }
     // Force synchronize settings and re-allocate frame buffer for redundancy
     // NOTE: although this might not be needed, assume that parseROSParams()
     //       is called only once per nodelet, thus ignore cost


### PR DESCRIPTION
Not all cameras support sensor scaling. This results in warnings as the driver fails to set the sensor scaling. I have added a simple check that figures out if the camera supports sensor scaling and only if so tries to set the value according to the parameter.