### PR TITLE
Added support for setting the software-gamma 

### DIFF
--- a/cfg/UEyeCam.cfg
+++ b/cfg/UEyeCam.cfg
@@ -78,6 +78,9 @@ gen.add("blue_gain", int_t, RECONFIGURE_RUNNING,
   "Gain percentage for blue channel", 0, 0, 100)
 gen.add("gain_boost", bool_t, RECONFIGURE_RUNNING,
   "Analog gain boost", False)
+gen.add("software_gamma", int_t, RECONFIGURE_RUNNING,
+  "Software gamma in percent", 100, 1, 1000)  
+
  
 gen.add("auto_exposure", bool_t, RECONFIGURE_RUNNING,
   "Auto exposure (a.k.a. auto shutter)", False)

--- a/include/ueye_cam/ueye_cam_driver.hpp
+++ b/include/ueye_cam/ueye_cam_driver.hpp
@@ -214,6 +214,17 @@ public:
       INT& green_gain_prc, INT& blue_gain_prc, bool& gain_boost);
 
   /**
+   * Updates current camera handle's software gamma to specified parameter.
+   *
+   * According to ids this is only possible when the color mode is debayered by the ids driver 
+   *
+   * \param software_gamma gamma value in percentage
+   *
+   * \return IS_SUCCESS if successful, error flag otherwise (see err2str).
+   */
+  INT setSoftwareGamma(INT& software_gamma);
+
+  /**
    * Updates current camera handle's exposure / shutter either to auto mode, or
    * to specified manual parameters.
    *

--- a/launch/debug.launch
+++ b/launch/debug.launch
@@ -38,6 +38,7 @@
     <param name="green_gain" type="int" value="1" />
     <param name="blue_gain" type="int" value="16" />
     <param name="gain_boost" type="bool" value="False" />
+    <param name="software_gamma" type="double" value="100.0" />
 
     <param name="auto_exposure" type="bool" value="False" />
     <param name="exposure" type="int" value="33" /> <!-- in ms -->

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -559,6 +559,31 @@ INT UEyeCamDriver::setGain(bool& auto_gain, INT& master_gain_prc, INT& red_gain_
 }
 
 
+INT UEyeCamDriver::setSoftwareGamma(INT& software_gamma) {
+  if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;
+
+  INT is_err = IS_SUCCESS;
+
+  // According to ids this is only possible when the color mode is debayered by the ids driver 
+  if ((color_mode_ == IS_CM_SENSOR_RAW8)  ||
+      (color_mode_ == IS_CM_SENSOR_RAW10) ||
+      (color_mode_ == IS_CM_SENSOR_RAW12) ||
+      (color_mode_ == IS_CM_SENSOR_RAW16)) {
+    WARN_STREAM("Software gamma only possible when the color mode is debayered, " <<
+    "could not set software gamma for [" << cam_name_ << "] (" << err2str(is_err) << ")"); 
+    return IS_NO_SUCCESS;    
+  }
+
+  // set software gamma 
+  if ((is_err = is_Gamma(cam_handle_, IS_GAMMA_CMD_SET, (void*) &software_gamma, sizeof(software_gamma))) != IS_SUCCESS) {
+    WARN_STREAM("Software gamma could not be set for [" << cam_name_ <<
+    "] (" << err2str(is_err) << ")");       
+  }  
+
+  return is_err;
+}
+
+
 INT UEyeCamDriver::setExposure(bool& auto_exposure, double& exposure_ms) {
   if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;
 

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -570,7 +570,7 @@ INT UEyeCamDriver::setSoftwareGamma(INT& software_gamma) {
       (color_mode_ == IS_CM_SENSOR_RAW12) ||
       (color_mode_ == IS_CM_SENSOR_RAW16)) {
     WARN_STREAM("Software gamma only possible when the color mode is debayered, " <<
-    "could not set software gamma for [" << cam_name_ << "] (" << err2str(is_err) << ")"); 
+    "could not set software gamma for [" << cam_name_ << "]"); 
     return IS_NO_SUCCESS;    
   }
 


### PR DESCRIPTION
Software-gamma belongs to the "gain section" of the driver and was not supported yet. Wiht this PR one can be set a desired software-gamma using a launch file (was added to the optional part of `debug.launch` as an example), on-device camera configs and  via `rqt_reconfigure`.

IDS states the default value to be 100. Therefore this parameter defaults to 100 if not specified elsewhere.