### PR TITLE
[uEye 4.94] Update Deprecated Event Handling Functions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ in a timely manner.
                           File -> save parameter -> to file...)
 
 
+**REQUIREMENTS:**  
+[IDS uEye Software Suite](https://en.ids-imaging.com/downloads.html) >= 4.94 
+
+
 **DOCUMENTATION:**
 
 www.ros.org/wiki/ueye_cam

--- a/include/ueye_cam/ueye_cam_driver.hpp
+++ b/include/ueye_cam/ueye_cam_driver.hpp
@@ -350,7 +350,7 @@ public:
    *         WARNING: image buffer contents may change during capture, or may become
    *         invalid after calling other functions!
    */
-  const char* processNextFrame(INT timeout_ms);
+  const char* processNextFrame(UINT timeout_ms);
 
   inline bool isConnected() { return (cam_handle_ != HIDS(0)); }
 

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -952,7 +952,7 @@ INT UEyeCamDriver::setStandbyMode() {
 }
 
 
-const char* UEyeCamDriver::processNextFrame(INT timeout_ms) {
+const char* UEyeCamDriver::processNextFrame(UINT timeout_ms) {
   if (!freeRunModeActive() && !extTriggerModeActive()) return nullptr;
 
   INT is_err = IS_SUCCESS;

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -1025,7 +1025,7 @@ void UEyeCamNodelet::frameGrabLoop() {
 #endif
 
     if (isCapturing()) {
-      INT eventTimeout = (cam_params_.auto_frame_rate || cam_params_.ext_trigger_mode) ?
+      UINT eventTimeout = (cam_params_.auto_frame_rate || cam_params_.ext_trigger_mode) ?
           static_cast<INT>(2000) : static_cast<INT>(1000.0 / cam_params_.frame_rate * 2);
       if (processNextFrame(eventTimeout) != nullptr) {
         // Initialize shared pointers from member messages for nodelet intraprocess publishing


### PR DESCRIPTION
With version 4.94 some API functions concerning the event handling became deprecated. With this PR the newer equivalent will be used. 

- The new API expects arrays as event(s) to process. The code got a bit longer as a single event needs to be expressed as an array first. This is due to the events themselves being #define macros which can not be called by a pointer.  

- Additionally, I added the initialization of the `IS_SET_EVENT_FRAME` event, which was missing before (old API already supported this) and seems to be mandatory now 

- Finally, I updated the readme to state the necessity of 4.94 and above. 

@jmackay2 maybe you have time to test this with hardware (I have tested it with mine)? It could then be merged. 