### PR TITLE
Added check if default file ini exists at all

### DIFF
--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -898,10 +898,13 @@ INT UEyeCamNodelet::connectCam() {
   if ((is_err = UEyeCamDriver::connectCam()) != IS_SUCCESS) return is_err;
 
   // (Attempt to) load UEye camera parameter configuration file
-  if (cam_params_filename_.length() <= 0) { // Use default filename
-    cam_params_filename_ = string(getenv("HOME")) + "/.ros/camera_conf/" + cam_name_ + ".ini";
+  if (cam_params_filename_.length() <= 0) { // Try to use default filename if not specified otherwise
+    std::string cam_params_filename_fallback = string(getenv("HOME")) + "/.ros/camera_conf/" + cam_name_ + ".ini";
+    if (access( cam_params_filename_fallback.c_str(), F_OK ) != -1 ) { cam_params_filename_=cam_params_filename_fallback;}
   }
-  if ((is_err = loadCamConfig(cam_params_filename_)) != IS_SUCCESS) return is_err;
+  if (cam_params_filename_.length() > 0) {
+    if ((is_err = loadCamConfig(cam_params_filename_)) != IS_SUCCESS) return is_err;
+  }
 
   // Query existing configuration parameters from camera
   if ((is_err = queryCamParams()) != IS_SUCCESS) return is_err;


### PR DESCRIPTION
Starting the development on this project I made the mistake to forget making a branch for this very first feature I implemented. I had to do a rebase last night in order to clean my forked master. This caused https://github.com/anqixu/ueye_cam/pull/88 to automatically close. This is the replacement PR.

What it does: 

**Before**
If no .ini file is stated in the launch file the driver tries to load a default file resulting in an error if this file does not exist
```
Could not load [camera]'s sensor parameters file /home/user/.ros/camera_conf/camera.ini
```
**With Patch**
I do not use .ini files at all. The driver will now check if the default (fallback) .ini exists at all before trying to load it. This avoids "errors" that are none by design. 
