### PR TITLE
Adding auto exposure reference value

### DIFF
--- a/cfg/UEyeCam.cfg
+++ b/cfg/UEyeCam.cfg
@@ -84,6 +84,8 @@ gen.add("software_gamma", int_t, RECONFIGURE_RUNNING,
  
 gen.add("auto_exposure", bool_t, RECONFIGURE_RUNNING,
   "Auto exposure (a.k.a. auto shutter)", False)
+gen.add("auto_exposure_reference", double_t, RECONFIGURE_RUNNING,
+  "Target for the exposure/gain brightness controller", 128, 0.0, 255.0)
 gen.add("exposure", double_t, RECONFIGURE_RUNNING,
   "Exposure value (ms)", 33.0, 0.0, 300.0)
  

--- a/include/ueye_cam/ueye_cam_driver.hpp
+++ b/include/ueye_cam/ueye_cam_driver.hpp
@@ -230,12 +230,13 @@ public:
    *
    * \param auto_exposure Updates camera's hardware auto shutter / auto shutter mode.
    *   Will be deactivated if camera does not support mode.
+   * \param auto_exposure_reference sets the reference value for the auto_exposure controller. 
    * \param exposure_ms Manual exposure setting, in ms. Valid value range depends on
    *   current camera pixel clock rate.
    *
    * \return IS_SUCCESS if successful, error flag otherwise (see err2str).
    */
-  INT setExposure(bool& auto_exposure, double& exposure_ms);
+  INT setExposure(bool& auto_exposure, double& auto_exposure_reference, double& exposure_ms);
 
   /**
    * Enables or disables the current camera handle's auto white balance mode, and

--- a/launch/debug.launch
+++ b/launch/debug.launch
@@ -41,6 +41,7 @@
     <param name="software_gamma" type="double" value="100.0" />
 
     <param name="auto_exposure" type="bool" value="False" />
+    <param name="auto_exposure_reference" type="double" value="128.0" />
     <param name="exposure" type="int" value="33" /> <!-- in ms -->
 
     <param name="auto_white_balance" type="bool" value="True" />

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -584,7 +584,7 @@ INT UEyeCamDriver::setSoftwareGamma(INT& software_gamma) {
 }
 
 
-INT UEyeCamDriver::setExposure(bool& auto_exposure, double& exposure_ms) {
+INT UEyeCamDriver::setExposure(bool& auto_exposure, double& auto_exposure_reference, double& exposure_ms) {
   if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;
 
   INT is_err = IS_SUCCESS;
@@ -602,6 +602,13 @@ INT UEyeCamDriver::setExposure(bool& auto_exposure, double& exposure_ms) {
       auto_exposure = false;
     }
   }
+
+  // Set exposure reference for auto exposure controller 
+  if ((is_err = is_SetAutoParameter (cam_handle_, IS_SET_AUTO_REFERENCE, 
+    &auto_exposure_reference, 0)) != IS_SUCCESS) {
+    WARN_STREAM("Auto exposure reference value could not be set for [" << cam_name_ <<
+    "] (" << err2str(is_err) << ")");      
+    }
 
   // Set manual exposure timing
   if (!auto_exposure) {

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -105,6 +105,7 @@ UEyeCamNodelet::UEyeCamNodelet():
   cam_params_.gain_boost = 0;
   cam_params_.software_gamma=100;
   cam_params_.auto_exposure = false;
+  cam_params_.auto_exposure_reference = 128;
   cam_params_.exposure = DEFAULT_EXPOSURE;
   cam_params_.auto_white_balance = false;
   cam_params_.white_balance_red_offset = 0;
@@ -192,6 +193,7 @@ void UEyeCamNodelet::onInit() {
       "Gain Boost:\t\t" << cam_params_.gain_boost << endl <<
       "Software Gamma:\t\t" << cam_params_.software_gamma << endl <<
       "Auto Exposure:\t\t" << cam_params_.auto_exposure << endl <<
+      "Auto Exposure Reference:\t" << cam_params_.auto_exposure_reference << endl <<
       "Exposure (ms):\t\t" << cam_params_.exposure << endl <<
       "Auto White Balance:\t" << cam_params_.auto_white_balance << endl <<
       "WB Red Offset:\t\t" << cam_params_.white_balance_red_offset << endl <<
@@ -388,6 +390,14 @@ INT UEyeCamNodelet::parseROSParams(ros::NodeHandle& local_nh) {
   } else {
     local_nh.setParam("auto_exposure", cam_params_.auto_exposure);
   }
+  if (local_nh.hasParam("auto_exposure_reference")) {
+    local_nh.getParam("auto_exposure_reference", cam_params_.auto_exposure_reference);
+    if (cam_params_.auto_exposure_reference != prevCamParams.auto_exposure_reference) {
+      hasNewParams = true;
+    }
+  } else {
+    local_nh.setParam("auto_exposure_reference", cam_params_.auto_exposure_reference);
+  }
   if (local_nh.hasParam("exposure")) {
     local_nh.getParam("exposure", cam_params_.exposure);
     if (cam_params_.exposure != prevCamParams.exposure) {
@@ -573,7 +583,7 @@ INT UEyeCamNodelet::parseROSParams(ros::NodeHandle& local_nh) {
     if ((is_err = setSoftwareGamma(cam_params_.software_gamma)) != IS_SUCCESS) noop;
     if ((is_err = setPixelClockRate(cam_params_.pixel_clock)) != IS_SUCCESS) return is_err;
     if ((is_err = setFrameRate(cam_params_.auto_frame_rate, cam_params_.frame_rate)) != IS_SUCCESS) return is_err;
-    if ((is_err = setExposure(cam_params_.auto_exposure, cam_params_.exposure)) != IS_SUCCESS) noop;
+    if ((is_err = setExposure(cam_params_.auto_exposure, cam_params_.auto_exposure_reference, cam_params_.exposure)) != IS_SUCCESS) noop;
     if ((is_err = setWhiteBalance(cam_params_.auto_white_balance, cam_params_.white_balance_red_offset,
       cam_params_.white_balance_blue_offset)) != IS_SUCCESS) noop;
     if ((is_err = setMirrorUpsideDown(cam_params_.flip_upd)) != IS_SUCCESS) noop;
@@ -698,8 +708,9 @@ void UEyeCamNodelet::configCallback(ueye_cam::UEyeCamConfig& config, uint32_t le
   }
 
   if (config.auto_exposure != cam_params_.auto_exposure ||
+      config.auto_exposure_reference != cam_params_.auto_exposure_reference ||
       config.exposure != cam_params_.exposure) {
-    if (setExposure(config.auto_exposure, config.exposure) != IS_SUCCESS) return;
+    if (setExposure(config.auto_exposure, cam_params_.auto_exposure_reference, config.exposure) != IS_SUCCESS) return;
   }
 
   if (config.auto_white_balance != cam_params_.auto_white_balance ||
@@ -837,6 +848,12 @@ INT UEyeCamNodelet::queryCamParams() {
     return is_err;
   }
   cam_params_.auto_exposure = (pval1 != 0);
+
+  if ((is_err = is_SetAutoParameter (cam_handle_, IS_GET_AUTO_REFERENCE, 
+      &cam_params_.auto_exposure_reference, 0)) != IS_SUCCESS) {
+    ERROR_STREAM("Failed to query exposure reference value for [" << cam_name_ <<
+      "] (" << err2str(is_err) << ")");    
+      }
 
   if ((is_err = is_Exposure(cam_handle_, IS_EXPOSURE_CMD_GET_EXPOSURE,
       &cam_params_.exposure, sizeof(cam_params_.exposure))) != IS_SUCCESS) {

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -710,7 +710,7 @@ void UEyeCamNodelet::configCallback(ueye_cam::UEyeCamConfig& config, uint32_t le
   if (config.auto_exposure != cam_params_.auto_exposure ||
       config.auto_exposure_reference != cam_params_.auto_exposure_reference ||
       config.exposure != cam_params_.exposure) {
-    if (setExposure(config.auto_exposure, cam_params_.auto_exposure_reference, config.exposure) != IS_SUCCESS) return;
+    if (setExposure(config.auto_exposure, config.auto_exposure_reference, config.exposure) != IS_SUCCESS) return;
   }
 
   if (config.auto_white_balance != cam_params_.auto_white_balance ||


### PR DESCRIPTION
This PR adds the capability of being able set the auto exposure reference value. This value is basically the set value for the auto exposure controller. If not set, it defaults to 128 which is the IDS default. 

@jmackay2 I will assign you for the review, I hope this is okay with you. I will make less PRs in the future, but I think it would be beneficial to have someone else testing the code as we deal with hardware and this comes always with more challenges.