### PR TITLE
Full GPIO Functionality

### DIFF
--- a/cfg/UEyeCam.cfg
+++ b/cfg/UEyeCam.cfg
@@ -102,6 +102,23 @@ gen.add("flash_duration", int_t, RECONFIGURE_RUNNING,
 gen.add("ext_trigger_mode", bool_t, RECONFIGURE_STOP,
   "Toggle between external trigger mode and free-run mode", False)
 
+gpio_enum = gen.enum([
+  gen.const("Input", int_t, 0, "Input"),
+  gen.const("Output_Low", int_t, 1, "Output Low"),
+  gen.const("Output_High", int_t, 2, "Output High"),
+  gen.const("Flash", int_t, 3, "Flash"),
+  gen.const("PWM_Output", int_t, 4, "PWM Output"),
+  gen.const("Trigger", int_t, 5, "Trigger")],
+  "Mode of a GPIO pin")
+gen.add("gpio1", int_t, RECONFIGURE_STOP,
+  "Mode for GPIO1 (pin 5)", 0, edit_method=gpio_enum)
+gen.add("gpio2", int_t, RECONFIGURE_STOP,
+  "Mode for GPIO2 (pin 6)", 0, edit_method=gpio_enum)
+gen.add("pwm_freq", double_t, RECONFIGURE_RUNNING,
+  "PWM output frequency", 1, 1, 10000)
+gen.add("pwm_duty_cycle", double_t, RECONFIGURE_RUNNING,
+  "PWM output duty cycle", 0.5, 0, 1) 
+
 gen.add("auto_frame_rate", bool_t, RECONFIGURE_RUNNING,
   "Auto frame rate (requires auto exposure, supercedes auto gain) [not applicable in external trigger mode]", False) 
 gen.add("frame_rate", double_t, RECONFIGURE_RUNNING,

--- a/include/ueye_cam/ueye_cam_driver.hpp
+++ b/include/ueye_cam/ueye_cam_driver.hpp
@@ -288,6 +288,17 @@ public:
   INT setFlashParams(INT& delay_us, UINT& duration_us);
 
   /**
+   * Sets the mode for the GPIO pins.
+   * \param GPIO pin to be set {GPIO1: 1, GPIO2: 2}.
+   * \param mode for GPIO pin {0: input, 1: output low, 2: output high, 3: flash, 4: pwm output, 5: trigger input}.
+   * \param pwm_freq frequency if pwm output is selected as the mode
+   * \param pwm_duty_cycle duty cycle if pwm output is selected as the mode
+   * 
+   * \return IS_SUCCESS if successful, error flag otherwise (see err2str).
+   */
+  INT setGpioMode(const INT& gpio, INT& mode, double& pwm_freq, double& pwm_duty_cycle);
+
+  /**
    * Sets current camera to start capturing frames to internal buffer repeatedly.
    * This function also pre-configures the camera to operate in free-run,
    * non-triggered mode, and further attempts to enable the digital output pin

--- a/launch/debug.launch
+++ b/launch/debug.launch
@@ -50,6 +50,8 @@
     <param name="flash_delay" type="int" value="0" /> <!-- in us -->
     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
 
+    <param name="gpio1" type="int" value="0" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
+
     <param name="auto_frame_rate" type="bool" value="False" />
     <param name="frame_rate" type="double" value="30.0" />
     <param name="output_rate" type="double" value="0.0" /> <!-- >0: throttle rate for publishing frames -->

--- a/launch/master_slaves_pwm_rgb8.launch
+++ b/launch/master_slaves_pwm_rgb8.launch
@@ -1,0 +1,167 @@
+<!-- In this example launch file one camera creates a pwm signal on GPIO 2 which can be used to
+     trigger itself and other cameras which have set their GPIO 1 to "trigger". For this to work
+     the cameras have to be in external trigger mode (ext_trigger_mode = true). The framerate can be set via
+     the pwm_freq setting. GPIO 2 of the master and GPIO 1 of all cameras (including the master) as well
+     as the ground have to be electrically connected via the I/O connecters of the cameras.
+     Note: Using the pwm is an (according to IDS official) alternative to the trigger a cameras. The other 
+     way (using the flash to trigger other cameras) is supported as well by this driver. The corresponding
+     configuration is shown in master_slaves_rgb8.launch -->
+
+<?xml version="1.0"?>
+<launch>
+     <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" output="screen" />
+
+     <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet_pwm_master"
+          args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
+     <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
+     <param name="camera_topic" type="str" value="image_raw" />
+     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
+
+     <param name="ext_trigger_mode" type="bool" value="true" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
+
+     <!-- the following are optional camera configuration parameters:
+          they will be loaded on the camera after the .ini configuration
+          file, and before dynamic_reconfigure. That means that any
+          (lingering) dynamic parameters from dynamic_reconfigure will
+          override these values, and that these will override parameters
+          from the .ini file.
+          See http://www.ros.org/wiki/ueye_cam for more details. -->
+
+     <param name="color_mode" type="str" value="rgb8" /> <!-- valid options: 'rgb8', 'mono8', 'bayer_rggb8' -->
+
+     <!-- WARNING: the following 4 parameters specify dimensions for camera's area of interest. Values for image_width and image_height that are smaller than your camera's maximum values will result in cropped field of view. For typical cases, one should modify values for sensor_scaling / binning / subsampling to downsample the resulting ROS image to the desired dimensions, without losing potential field of view. -->
+     <param name="image_width" type="int" value="640" />
+     <param name="image_height" type="int" value="480" />
+     <param name="image_top" type="int" value="-1" /> <!-- -1: center -->
+     <param name="image_left" type="int" value="-1" /> <!-- -1: center -->
+
+     <param name="subsampling" type="int" value="1" /> <!-- supported by only some UEye cameras -->
+     <param name="binning" type="int" value="1" /> <!-- supported by only some UEye cameras -->
+     <param name="sensor_scaling" type="double" value="1.0" /> <!-- supported by only some UEye cameras -->
+
+     <param name="auto_gain" type="bool" value="True" />
+     <param name="master_gain" type="int" value="0" />
+     <param name="red_gain" type="int" value="0" />
+     <param name="green_gain" type="int" value="1" />
+     <param name="blue_gain" type="int" value="16" />
+     <param name="gain_boost" type="bool" value="False" />
+
+     <param name="auto_exposure" type="bool" value="False" />
+     <param name="exposure" type="int" value="33" /> <!-- in ms -->
+
+     <param name="auto_white_balance" type="bool" value="True" />
+     <param name="white_balance_red_offset" type="int" value="0" />
+     <param name="white_balance_blue_offset" type="int" value="0" />
+
+     <param name="flash_delay" type="int" value="30000" /> <!-- in us -->
+     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
+
+     <param name="gpio2" type="int" value="4" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
+     <param name="pwm_freq" type="double" value="1 " /> <!-- in hz, This will determine the framerate of all cameras -->
+     <param name="gpio1" type="int" value="5" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
+
+     <param name="pixel_clock" type="int" value="30" />
+     </node>
+
+     <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet_slave1"
+          args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
+     <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
+     <param name="camera_topic" type="str" value="image_raw" />
+     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
+
+     <param name="ext_trigger_mode" type="bool" value="true" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
+
+     <!-- the following are optional camera configuration parameters:
+          they will be loaded on the camera after the .ini configuration
+          file, and before dynamic_reconfigure. That means that any
+          (lingering) dynamic parameters from dynamic_reconfigure will
+          override these values, and that these will override parameters
+          from the .ini file.
+          See http://www.ros.org/wiki/ueye_cam for more details. -->
+
+     <param name="color_mode" type="str" value="rgb8" /> <!-- valid options: 'rgb8', 'mono8', 'bayer_rggb8' -->
+
+     <!-- WARNING: the following 4 parameters specify dimensions for camera's area of interest. Values for image_width and image_height that are smaller than your camera's maximum values will result in cropped field of view. For typical cases, one should modify values for sensor_scaling / binning / subsampling to downsample the resulting ROS image to the desired dimensions, without losing potential field of view. -->
+     <param name="image_width" type="int" value="640" />
+     <param name="image_height" type="int" value="480" />
+     <param name="image_top" type="int" value="-1" /> <!-- -1: center -->
+     <param name="image_left" type="int" value="-1" /> <!-- -1: center -->
+
+     <param name="subsampling" type="int" value="1" /> <!-- supported by only some UEye cameras -->
+     <param name="binning" type="int" value="1" /> <!-- supported by only some UEye cameras -->
+     <param name="sensor_scaling" type="double" value="1.0" /> <!-- supported by only some UEye cameras -->
+
+     <param name="auto_gain" type="bool" value="True" />
+     <param name="master_gain" type="int" value="0" />
+     <param name="red_gain" type="int" value="0" />
+     <param name="green_gain" type="int" value="1" />
+     <param name="blue_gain" type="int" value="16" />
+     <param name="gain_boost" type="bool" value="False" />
+
+     <param name="auto_exposure" type="bool" value="False" />
+     <param name="exposure" type="int" value="33" /> <!-- in ms -->
+
+     <param name="auto_white_balance" type="bool" value="True" />
+     <param name="white_balance_red_offset" type="int" value="0" />
+     <param name="white_balance_blue_offset" type="int" value="0" />
+
+     <param name="flash_delay" type="int" value="30000" /> <!-- in us -->
+     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
+
+     
+     <param name="gpio1" type="int" value="5" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
+
+     <param name="pixel_clock" type="int" value="30" />
+     </node>
+
+     <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet_slave2"
+          args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
+     <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
+     <param name="camera_topic" type="str" value="image_raw" />
+     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
+
+     <param name="ext_trigger_mode" type="bool" value="true" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
+
+     <!-- the following are optional camera configuration parameters:
+          they will be loaded on the camera after the .ini configuration
+          file, and before dynamic_reconfigure. That means that any
+          (lingering) dynamic parameters from dynamic_reconfigure will
+          override these values, and that these will override parameters
+          from the .ini file.
+          See http://www.ros.org/wiki/ueye_cam for more details. -->
+
+     <param name="color_mode" type="str" value="rgb8" /> <!-- valid options: 'rgb8', 'mono8', 'bayer_rggb8' -->
+
+     <!-- WARNING: the following 4 parameters specify dimensions for camera's area of interest. Values for image_width and image_height that are smaller than your camera's maximum values will result in cropped field of view. For typical cases, one should modify values for sensor_scaling / binning / subsampling to downsample the resulting ROS image to the desired dimensions, without losing potential field of view. -->
+     <param name="image_width" type="int" value="640" />
+     <param name="image_height" type="int" value="480" />
+     <param name="image_top" type="int" value="-1" /> <!-- -1: center -->
+     <param name="image_left" type="int" value="-1" /> <!-- -1: center -->
+
+     <param name="subsampling" type="int" value="1" /> <!-- supported by only some UEye cameras -->
+     <param name="binning" type="int" value="1" /> <!-- supported by only some UEye cameras -->
+     <param name="sensor_scaling" type="double" value="1.0" /> <!-- supported by only some UEye cameras -->
+
+     <param name="auto_gain" type="bool" value="True" />
+     <param name="master_gain" type="int" value="0" />
+     <param name="red_gain" type="int" value="0" />
+     <param name="green_gain" type="int" value="1" />
+     <param name="blue_gain" type="int" value="16" />
+     <param name="gain_boost" type="bool" value="False" />
+
+     <param name="auto_exposure" type="bool" value="False" />
+     <param name="exposure" type="int" value="33" /> <!-- in ms -->
+
+     <param name="auto_white_balance" type="bool" value="True" />
+     <param name="white_balance_red_offset" type="int" value="0" />
+     <param name="white_balance_blue_offset" type="int" value="0" />
+
+     <param name="flash_delay" type="int" value="30000" /> <!-- in us -->
+     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
+
+     
+     <param name="gpio1" type="int" value="5" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
+
+     <param name="pixel_clock" type="int" value="30" />
+     </node>
+</launch>

--- a/launch/master_slaves_pwm_rgb8.launch
+++ b/launch/master_slaves_pwm_rgb8.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!-- In this example launch file one camera creates a pwm signal on GPIO 2 which can be used to
      trigger itself and other cameras which have set their GPIO 1 to "trigger". For this to work
      the cameras have to be in external trigger mode (ext_trigger_mode = true). The framerate can be set via
@@ -7,7 +8,6 @@
      way (using the flash to trigger other cameras) is supported as well by this driver. The corresponding
      configuration is shown in master_slaves_rgb8.launch -->
 
-<?xml version="1.0"?>
 <launch>
      <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" output="screen" />
 
@@ -15,7 +15,7 @@
           args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
      <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
      <param name="camera_topic" type="str" value="image_raw" />
-     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
+     <param name="camera_id" type="int" value="10" /> <!-- 0 = any camera; 1+: camera ID -->
 
      <param name="ext_trigger_mode" type="bool" value="true" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 
@@ -57,7 +57,7 @@
      <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
 
      <param name="gpio2" type="int" value="4" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
-     <param name="pwm_freq" type="double" value="1 " /> <!-- in hz, This will determine the framerate of all cameras -->
+     <param name="pwm_freq" type="double" value="10" /> <!-- in hz, This will determine the framerate of all cameras -->
      <param name="gpio1" type="int" value="5" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
 
      <param name="pixel_clock" type="int" value="30" />
@@ -65,60 +65,9 @@
 
      <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet_slave1"
           args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
-     <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
+     <param name="camera_name" type="str" value="slave1" /> <!-- == namespace for topics and services -->
      <param name="camera_topic" type="str" value="image_raw" />
-     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
-
-     <param name="ext_trigger_mode" type="bool" value="true" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
-
-     <!-- the following are optional camera configuration parameters:
-          they will be loaded on the camera after the .ini configuration
-          file, and before dynamic_reconfigure. That means that any
-          (lingering) dynamic parameters from dynamic_reconfigure will
-          override these values, and that these will override parameters
-          from the .ini file.
-          See http://www.ros.org/wiki/ueye_cam for more details. -->
-
-     <param name="color_mode" type="str" value="rgb8" /> <!-- valid options: 'rgb8', 'mono8', 'bayer_rggb8' -->
-
-     <!-- WARNING: the following 4 parameters specify dimensions for camera's area of interest. Values for image_width and image_height that are smaller than your camera's maximum values will result in cropped field of view. For typical cases, one should modify values for sensor_scaling / binning / subsampling to downsample the resulting ROS image to the desired dimensions, without losing potential field of view. -->
-     <param name="image_width" type="int" value="640" />
-     <param name="image_height" type="int" value="480" />
-     <param name="image_top" type="int" value="-1" /> <!-- -1: center -->
-     <param name="image_left" type="int" value="-1" /> <!-- -1: center -->
-
-     <param name="subsampling" type="int" value="1" /> <!-- supported by only some UEye cameras -->
-     <param name="binning" type="int" value="1" /> <!-- supported by only some UEye cameras -->
-     <param name="sensor_scaling" type="double" value="1.0" /> <!-- supported by only some UEye cameras -->
-
-     <param name="auto_gain" type="bool" value="True" />
-     <param name="master_gain" type="int" value="0" />
-     <param name="red_gain" type="int" value="0" />
-     <param name="green_gain" type="int" value="1" />
-     <param name="blue_gain" type="int" value="16" />
-     <param name="gain_boost" type="bool" value="False" />
-
-     <param name="auto_exposure" type="bool" value="False" />
-     <param name="exposure" type="int" value="33" /> <!-- in ms -->
-
-     <param name="auto_white_balance" type="bool" value="True" />
-     <param name="white_balance_red_offset" type="int" value="0" />
-     <param name="white_balance_blue_offset" type="int" value="0" />
-
-     <param name="flash_delay" type="int" value="30000" /> <!-- in us -->
-     <param name="flash_duration" type="int" value="1000" /> <!-- in us -->
-
-     
-     <param name="gpio1" type="int" value="5" /> <!-- 0 Input, 1 Output Low, 2 Output High, 3 Flash, 4 PWM, 5 Trigger input  -->
-
-     <param name="pixel_clock" type="int" value="30" />
-     </node>
-
-     <node pkg="nodelet" type="nodelet" name="ueye_cam_nodelet_slave2"
-          args="load ueye_cam/ueye_cam_nodelet nodelet_manager">
-     <param name="camera_name" type="str" value="master" /> <!-- == namespace for topics and services -->
-     <param name="camera_topic" type="str" value="image_raw" />
-     <param name="camera_id" type="int" value="0" /> <!-- 0 = any camera; 1+: camera ID -->
+     <param name="camera_id" type="int" value="11" /> <!-- 0 = any camera; 1+: camera ID -->
 
      <param name="ext_trigger_mode" type="bool" value="true" /> <!-- if False, then camera will operate in free-run mode; otherwise, frames need to be triggered by hardware signal (falling-edge) on digital input pin of camera -->
 

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -814,6 +814,51 @@ INT UEyeCamDriver::setFlashParams(INT& delay_us, UINT& duration_us) {
 }
 
 
+INT UEyeCamDriver::setGpioMode(const int& gpio, int& mode, double& pwm_freq, double& pwm_duty_cycle) {
+  /* Set GPIO to a specific mode. */
+  INT is_err = IS_SUCCESS;
+  IO_GPIO_CONFIGURATION gpioConfiguration;
+  gpioConfiguration.u32State = 0;
+  IO_PWM_PARAMS m_pwmParams;
+  
+  if (gpio == 1) 
+    gpioConfiguration.u32Gpio = IO_GPIO_1; // GPIO1 (pin 5).
+  else if (gpio == 2) 
+    gpioConfiguration.u32Gpio = IO_GPIO_2; // GPIO2 (pin 6).
+
+  switch (mode) {
+  case 0: gpioConfiguration.u32Configuration = IS_GPIO_INPUT; break;  
+  case 1: gpioConfiguration.u32Configuration = IS_GPIO_OUTPUT; break;
+  case 2:
+          gpioConfiguration.u32Configuration = IS_GPIO_OUTPUT;
+          gpioConfiguration.u32State = 1;
+          break;
+  case 3: gpioConfiguration.u32Configuration = IS_GPIO_FLASH; break;
+  case 4:
+          gpioConfiguration.u32Configuration = IS_GPIO_PWM;  
+          m_pwmParams.dblFrequency_Hz = pwm_freq;
+          m_pwmParams.dblDutyCycle = pwm_duty_cycle;
+          break;
+  case 5: gpioConfiguration.u32Configuration = IS_GPIO_TRIGGER;  break;
+  }
+  
+  // set GPIO regarding the selected pind and mode
+  if ((is_err = is_IO(cam_handle_, IS_IO_CMD_GPIOS_SET_CONFIGURATION, (void*)&gpioConfiguration, sizeof(gpioConfiguration))) != IS_SUCCESS) { 
+    ERROR_STREAM("Tried to set GPIO: " << gpioConfiguration.u32Gpio << " and got error code:  " << is_err); 
+  }
+
+  // Set PWM details if prior change of GPIO was successfull and mode is PWM 
+  if ((is_err == IS_SUCCESS) && (mode == 4)) {
+    if ((is_err = is_IO(cam_handle_, IS_IO_CMD_PWM_SET_PARAMS, (void*)&m_pwmParams, sizeof(m_pwmParams))) != IS_SUCCESS) {
+      ERROR_STREAM("Tried to set PWM to: " << m_pwmParams.dblFrequency_Hz << " hz and " << m_pwmParams.dblDutyCycle << 
+      " % and got error code:  " << is_err);   
+    }  
+  }
+
+  return is_err;
+}
+
+
 INT UEyeCamDriver::setFreeRunMode() {
   if (!isConnected()) return IS_INVALID_CAMERA_HANDLE;
 

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -116,6 +116,10 @@ UEyeCamNodelet::UEyeCamNodelet():
   cam_params_.ext_trigger_mode = false;
   cam_params_.flash_delay = 0;
   cam_params_.flash_duration = DEFAULT_FLASH_DURATION;
+  cam_params_.gpio1 = 0;
+  cam_params_.gpio2 = 0;
+  cam_params_.pwm_freq = 1;
+  cam_params_.pwm_duty_cycle=0.5;
   cam_params_.flip_upd = false;
   cam_params_.flip_lr = false;
 }
@@ -203,6 +207,8 @@ void UEyeCamNodelet::onInit() {
       "Frame Rate (Hz):\t" << cam_params_.frame_rate << endl <<
       "Output Rate (Hz):\t" << cam_params_.output_rate << endl <<
       "Pixel Clock (MHz):\t" << cam_params_.pixel_clock << endl <<
+      "GPIO1 Mode:\t" << cam_params_.gpio1 << endl <<
+      "GPIO2 Mode:\t" << cam_params_.gpio1 << endl <<
       "Mirror Image Upside Down:\t" << cam_params_.flip_upd << endl <<
       "Mirror Image Left Right:\t" << cam_params_.flip_lr << endl
       );
@@ -470,6 +476,31 @@ INT UEyeCamNodelet::parseROSParams(ros::NodeHandle& local_nh) {
   } else {
     local_nh.setParam("flash_duration", cam_params_.flash_duration);
   }
+  if (local_nh.hasParam("gpio1")) {
+    local_nh.getParam("gpio1", cam_params_.gpio1);
+    if (cam_params_.gpio1 != prevCamParams.gpio1) {hasNewParams = true;}
+  } else {
+    local_nh.setParam("gpio1", cam_params_.gpio1);
+  }
+  if (local_nh.hasParam("gpio2")) {
+    local_nh.getParam("gpio2", cam_params_.gpio2);
+    if (cam_params_.gpio2 != prevCamParams.gpio2) {hasNewParams = true;}
+  } else {
+    local_nh.setParam("gpio2", cam_params_.gpio2);
+  }
+  if (local_nh.hasParam("pwm_freq")) {
+    local_nh.getParam("pwm_freq", cam_params_.pwm_freq);
+    if (cam_params_.pwm_freq != prevCamParams.pwm_freq) {hasNewParams = true;}
+  } else {
+    local_nh.setParam("pwm_freq", cam_params_.pwm_freq);
+  }
+  if (local_nh.hasParam("pwm_duty_cycle")) {
+    local_nh.getParam("pwm_duty_cycle", cam_params_.pwm_duty_cycle);
+    if (cam_params_.pwm_duty_cycle != prevCamParams.pwm_duty_cycle) {hasNewParams = true;}
+  } else {
+    local_nh.setParam("pwm_duty_cycle", cam_params_.pwm_duty_cycle);
+  }
+
   if (local_nh.hasParam("auto_frame_rate")) {
     local_nh.getParam("auto_frame_rate", cam_params_.auto_frame_rate);
     if (cam_params_.auto_frame_rate != prevCamParams.auto_frame_rate) {
@@ -576,6 +607,8 @@ INT UEyeCamNodelet::parseROSParams(ros::NodeHandle& local_nh) {
     if ((is_err = setExposure(cam_params_.auto_exposure, cam_params_.exposure)) != IS_SUCCESS) noop;
     if ((is_err = setWhiteBalance(cam_params_.auto_white_balance, cam_params_.white_balance_red_offset,
       cam_params_.white_balance_blue_offset)) != IS_SUCCESS) noop;
+    if ((is_err = setGpioMode(1, cam_params_.gpio1, cam_params_.pwm_freq, cam_params_.pwm_duty_cycle)) != IS_SUCCESS) noop;
+    if ((is_err = setGpioMode(2, cam_params_.gpio2, cam_params_.pwm_freq, cam_params_.pwm_duty_cycle)) != IS_SUCCESS) noop;  
     if ((is_err = setMirrorUpsideDown(cam_params_.flip_upd)) != IS_SUCCESS) noop;
     if ((is_err = setMirrorLeftRight(cam_params_.flip_lr)) != IS_SUCCESS) noop;
     #undef noop
@@ -729,6 +762,16 @@ void UEyeCamNodelet::configCallback(ueye_cam::UEyeCamConfig& config, uint32_t le
     // Copy back actual flash parameter values that were set
     config.flash_delay = flash_delay;
     config.flash_duration = static_cast<int>(flash_duration);
+  }
+
+  // Change gpio if mode has changed OR if mode is pwm and pwm settings have been changed 
+  if ((config.gpio1 != cam_params_.gpio1) || 
+      (config.gpio1 == 4 && ((config.pwm_freq != cam_params_.pwm_freq) || (config.pwm_duty_cycle != cam_params_.pwm_duty_cycle)))) {
+    if (setGpioMode(1, config.gpio1, config.pwm_freq, config.pwm_duty_cycle) != IS_SUCCESS) return; 
+  }
+  if ((config.gpio2 != cam_params_.gpio2) || 
+      (config.gpio2 == 4 && ((config.pwm_freq != cam_params_.pwm_freq) || (config.pwm_duty_cycle != cam_params_.pwm_duty_cycle)))) {
+    if (setGpioMode(2, config.gpio2, config.pwm_freq, config.pwm_duty_cycle) != IS_SUCCESS) return; 
   }
 
   // Update local copy of parameter set to newly updated set


### PR DESCRIPTION
**What this PR does**
This PR adds the ability to *optionally* set the two GPIOs of the cameras. If not set, it defaults to `input` in order to no break something.

**What can the GPIOs be set to?**
- Input
- Output Low
- Output High
- PWM (including frequency and duty cycle)
- Trigger (input)

**What else**
I have added an additional launch file to show an alternative way to create master-slaves setup. In this setup one camera creates a pwm output to trigger itself and other cameras

@jmackay2 again, I will ask for your time to review this please. I can imagine, that not everybody has the right cable. Therefore, you might can just review the code and see if it compiles fine in your setup without testing the GPIO functionality in case you do not have the right cable?