### PR TITLE
Adding call of exit routine for the frame event

### DIFF
--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -942,6 +942,11 @@ INT UEyeCamDriver::setStandbyMode() {
           "] (" << err2str(is_err) << ")");
         return is_err;
       }
+      if ((is_err = is_Event(cam_handle_,IS_EVENT_CMD_EXIT, events, sizeof(events))) != IS_SUCCESS) {
+        ERROR_STREAM("Could not exit frame event for [" << cam_name_ <<
+          "] (" << err2str(is_err) << ")");
+        return is_err;
+      }         
       if ((is_err = is_SetExternalTrigger(cam_handle_, IS_SET_TRIGGER_OFF)) != IS_SUCCESS) {
         ERROR_STREAM("Could not disable external trigger mode for [" << cam_name_ <<
           "] (" << err2str(is_err) << ")");
@@ -967,6 +972,11 @@ INT UEyeCamDriver::setStandbyMode() {
         "] (" << err2str(is_err) << ")");
       return is_err;
     }
+    if ((is_err = is_Event(cam_handle_,IS_EVENT_CMD_EXIT, events, sizeof(events))) != IS_SUCCESS) {
+      ERROR_STREAM("Could not exit frame event for [" << cam_name_ <<
+        "] (" << err2str(is_err) << ")");
+      return is_err;
+    }       
     if ((is_err = is_StopLiveVideo(cam_handle_, IS_WAIT)) != IS_SUCCESS) {
       ERROR_STREAM("Could not stop live video mode for [" << cam_name_ <<
         "] (" << err2str(is_err) << ")");


### PR DESCRIPTION
**This PR adds exiting of the frame event:**
- According to the [manual](https://en.ids-imaging.com/manuals/ids-software-suite/ueye-manual/4.94/en/sdk_funktionsbloecke_event_handling.html?q=event) events should: Initialize, be enabled, getting used (waiting in out case), be disabled and exit. 
- In https://github.com/anqixu/ueye_cam/pull/97 only the conversion to 4.94 was done - including the adding of the initialization. Proper exiting was missing and should be enabled with this PR. 
