### PR TITLE
Fix IS_INVALID_BUFFER_SIZE bug. Consider absolute X and Y for memory …

### DIFF
--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -1174,10 +1174,27 @@ INT UEyeCamDriver::reallocateCamBuffer() {
     return is_err;
   }
 
+  INT width = cam_aoi_.s32Width ;
+  INT height = cam_aoi_.s32Height;
+
+  if((cam_aoi_.s32X > 0) || (cam_aoi_.s32Y > 0))
+  {
+    SENSORINFO m_sInfo;
+    
+	  if((is_err = is_GetSensorInfo(cam_handle_, &m_sInfo)) != IS_SUCCESS) {
+      ERROR_STREAM("Could not retrieve Sensor Info for [" <<
+        cam_name_ << "] (" << err2str(is_err) << ")");
+      return is_err;
+    }
+
+    width = m_sInfo.nMaxWidth;
+    height = m_sInfo.nMaxHeight;
+  }
+  
   // Allocate new memory section for IDS driver to use as frame buffer
-  if ((is_err = is_AllocImageMem(cam_handle_, cam_aoi_.s32Width, cam_aoi_.s32Height,
-      bits_per_pixel_, &cam_buffer_, &cam_buffer_id_)) != IS_SUCCESS) {
-    ERROR_STREAM("Failed to allocate " << cam_aoi_.s32Width << " x " << cam_aoi_.s32Height <<
+  if ((is_err = is_AllocImageMem(cam_handle_, width , height,
+    bits_per_pixel_, &cam_buffer_, &cam_buffer_id_)) != IS_SUCCESS) {
+    ERROR_STREAM("Failed to allocate " << width << " x " << height <<
       " image buffer for [" << cam_name_ << "]");
     return is_err;
   }

--- a/src/ueye_cam_driver.cpp
+++ b/src/ueye_cam_driver.cpp
@@ -1174,21 +1174,46 @@ INT UEyeCamDriver::reallocateCamBuffer() {
     return is_err;
   }
 
-  INT width = cam_aoi_.s32Width ;
-  INT height = cam_aoi_.s32Height;
+  INT width = cam_aoi_.s32Width  ;
+  INT height = cam_aoi_.s32Height ;
 
-  if((cam_aoi_.s32X > 0) || (cam_aoi_.s32Y > 0))
+  UINT start_posX_absolute = 0;
+  UINT start_posY_absolute = 0;
+
+  if ((is_err = is_AOI(cam_handle_, IS_AOI_IMAGE_GET_POS_X_ABS,
+      (void*) &start_posX_absolute, sizeof(start_posX_absolute))) != IS_SUCCESS) {
+    ERROR_STREAM("Could not retrieve Area Of Interest (AOI) information for parameter start X absolute for[" <<
+      cam_name_ << "] (" << err2str(is_err) << ")");
+    return is_err;
+  }
+
+  if ((is_err = is_AOI(cam_handle_, IS_AOI_IMAGE_GET_POS_Y_ABS,
+      (void*) &start_posY_absolute, sizeof(start_posY_absolute))) != IS_SUCCESS) {
+    ERROR_STREAM("Could not retrieve Area Of Interest (AOI) information for parameter start Y absolute for[" <<
+      cam_name_ << "] (" << err2str(is_err) << ")");
+    return is_err;
+  }
+
+  if ((start_posX_absolute == IS_AOI_IMAGE_POS_ABSOLUTE) ||
+      (start_posY_absolute == IS_AOI_IMAGE_POS_ABSOLUTE))
   {
     SENSORINFO m_sInfo;
     
-	  if((is_err = is_GetSensorInfo(cam_handle_, &m_sInfo)) != IS_SUCCESS) {
+    if((is_err = is_GetSensorInfo(cam_handle_, &m_sInfo)) != IS_SUCCESS ) {
       ERROR_STREAM("Could not retrieve Sensor Info for [" <<
         cam_name_ << "] (" << err2str(is_err) << ")");
       return is_err;
     }
 
-    width = m_sInfo.nMaxWidth;
-    height = m_sInfo.nMaxHeight;
+    if ((start_posX_absolute == IS_AOI_IMAGE_POS_ABSOLUTE) && (cam_aoi_.s32X > 0))
+    {
+      width = m_sInfo.nMaxWidth;
+    }
+
+    if ((start_posY_absolute == IS_AOI_IMAGE_POS_ABSOLUTE) && (cam_aoi_.s32Y > 0))
+    {
+      height = m_sInfo.nMaxHeight;
+    }
   }
   
   // Allocate new memory section for IDS driver to use as frame buffer

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -1258,7 +1258,7 @@ bool UEyeCamNodelet::fillMsgData(sensor_msgs::Image& img) const {
   } else { // cam_buffer_pitch_ > expected_row_stride
     // Each row contains extra buffer according to cam_buffer_pitch_, so must copy out each row independently
     uint8_t* dst_ptr = img.data.data();
-    char* cam_buffer_ptr = cam_buffer_ + cam_aoi_.s32X + (cam_aoi_.s32Y * cam_buffer_pitch_);
+    char* cam_buffer_ptr = cam_buffer_;
     for (INT row = 0; row < cam_aoi_.s32Height; row++) {
       unpackCopy(dst_ptr, cam_buffer_ptr, static_cast<unsigned long>(expected_row_stride));
       cam_buffer_ptr += cam_buffer_pitch_;

--- a/src/ueye_cam_nodelet.cpp
+++ b/src/ueye_cam_nodelet.cpp
@@ -1258,7 +1258,7 @@ bool UEyeCamNodelet::fillMsgData(sensor_msgs::Image& img) const {
   } else { // cam_buffer_pitch_ > expected_row_stride
     // Each row contains extra buffer according to cam_buffer_pitch_, so must copy out each row independently
     uint8_t* dst_ptr = img.data.data();
-    char* cam_buffer_ptr = cam_buffer_;
+    char* cam_buffer_ptr = cam_buffer_ + cam_aoi_.s32X + (cam_aoi_.s32Y * cam_buffer_pitch_);
     for (INT row = 0; row < cam_aoi_.s32Height; row++) {
       unpackCopy(dst_ptr, cam_buffer_ptr, static_cast<unsigned long>(expected_row_stride));
       cam_buffer_ptr += cam_buffer_pitch_;


### PR DESCRIPTION
**Issue:-**
[ERROR] [1611661455.769880480]: Could not start free-run live video mode for [camera] (IS_INVALID_BUFFER_SIZE)
This error appears only when x and y coordinates are more than 0.

**Solution:-** Consider absolute value of X and Y for memory allocation when it's more than 0.