### PR TITLE
Fix const warning range for loop

### DIFF
--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -1870,7 +1870,7 @@ INT Driver::name2colormode(const std::string& name) {
 
 
 const std::string Driver::colormode2name(INT mode) {
-  for (const std::pair<std::string, INT>& value: COLOR_DICTIONARY) {
+  for (const std::pair<const std::string, INT>& value: COLOR_DICTIONARY) {
     if (value.second == mode) {
       return value.first;
     }


### PR DESCRIPTION
This fixes the following warning to prevent copying:
```
error: loop variable 'value' of type 'const std::pair<std::__cxx11::basic_string<char>, int>&' binds to a temporary constructed from type 'const std::pair<const std::__cxx11::basic_string<char>, int>' [-Werror=range-loop-construct] 1873 | for (const std::pair<std::string, INT>& value: COLOR_DICTIONARY) {
```